### PR TITLE
Add pegasus frontend

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -49,11 +49,20 @@
     , ...
     }:
     let
+      pegasus-overlay =
+        (final: prev: {
+          pegasus-frontend = prev.pegasus-frontend.overrideAttrs (old: {
+            patches = [ "${old.src}/etc/rpi4/kms_launch_fix.diff" ./private-headers.diff ];
+          });
+        });
       pkgs = import nixpkgs {
         system = "x86_64-linux";
         overlays =
           (import ./overlays/arduino arduino-nix arduino-index) ++
-          [ (import ./overlays/cs-firmware) ];
+          [
+            (import ./overlays/cs-firmware)
+            pegasus-overlay
+          ];
       };
 
       cs-firmware = pkgs.cs-firmware;
@@ -93,12 +102,14 @@
                     (import ./overlays/alsa-utils.nix)
                     (import ./overlays/cs-hud)
                     (import ./overlays/flash-cs-firmware.nix)
-                    (import ./overlays/mesa.nix)
+                    # Use the default mesa package for now
+                    # (import ./overlays/mesa.nix)
                     (import ./overlays/ovmerge.nix ovmerge-src)
                     (import ./overlays/retroarch.nix retroarch-src)
                     (import ./overlays/rtl8723-firmware.nix)
                     (import ./overlays/uboot.nix)
                     (import ./overlays/wiringpi)
+                    pegasus-overlay
                   ] ++ (import ./overlays/arduino arduino-nix arduino-index);
                 };
               })
@@ -114,6 +125,8 @@
       };
 
       packages.x86_64-linux.cs-firmware = cs-firmware;
+      # To debug the build on the host
+      packages.x86_64-linux.pegasus-frontend = pkgs.pegasus-frontend;
 
       devShell.x86_64-linux =
         pkgs.mkShell {

--- a/private-headers.diff
+++ b/private-headers.diff
@@ -1,0 +1,22 @@
+diff --git a/src/backend/CMakeLists.txt b/src/backend/CMakeLists.txt
+index 08de0be7..88ea34e5 100644
+--- a/src/backend/CMakeLists.txt
++++ b/src/backend/CMakeLists.txt
+@@ -43,6 +43,7 @@ pegasus_require_qt(COMPONENTS
+     Multimedia
+     Sql
+     Svg
++    EglFSDeviceIntegration
+ )
+ target_link_libraries(pegasus-backend PUBLIC
+     Qt::Qml
+@@ -52,6 +53,9 @@ target_link_libraries(pegasus-backend PUBLIC
+     Qt::Svg
+     SortFilterProxyModel
+ )
++target_include_directories(pegasus-backend PRIVATE
++  ${Qt5EglFSDeviceIntegration_PRIVATE_INCLUDE_DIRS}
++)
+ 
+ include(PegasusCommonProps)
+ pegasus_add_common_props_optimized(pegasus-backend)

--- a/system/configuration.nix
+++ b/system/configuration.nix
@@ -54,6 +54,7 @@
   environment.systemPackages = [
     pkgs.alsa-utils
     pkgs.cs-hud
+    pkgs.pegasus-frontend
     pkgs.retroarch
     pkgs.vim
     pkgs.wiringpi


### PR DESCRIPTION
Draft PR to trying to make `pegasus-frontend` work. The configuration builds fine however pegasus fails to starts with:

```
[root@circuix:/home/pi]# systemctl stop retroarch

[root@circuix:/home/pi]# pegasus-fe
qt.qpa.xcb: could not connect to display
qt.qpa.plugin: Could not load the Qt platform plugin "xcb" in "" even though it was found.
This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.

Available platform plugins are: wayland-egl, wayland, wayland-xcomposite-egl, wayland-xcomposite-glx, eglfs, linuxfb, minimal, minimalegl, offscreen, vnc, xcb.

Aborted                    (core dumped) pegasus-fe
```

It looks like [it works fine on raspbian](https://pegasus-frontend.org/docs/user-guide/platform-raspberry/). Then there is no reason it cannot work on `circuix`. One needs to dig in the compilation options and the command they use to run it.